### PR TITLE
Update path to changed files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'charts/**'
+      - 'stable/locust/**'
 
 jobs:
   release:


### PR DESCRIPTION
Noticed that the release action didnt run when you merged to `master`. The path was incorrect for this repository.  Changing it to the correct path.