### PR TITLE
Add extraPaths to Ingress

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: locust
-version: "0.9.9"
+version: "0.9.10"
 appVersion: 1.4.3
 home: https://github.com/locustio/locust
 icon: https://locust.io/static/img/logo.png

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -52,6 +52,7 @@ helm install my-release locustio/locust -f values.yaml
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
+| ingress.extraPaths | list | `[]` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.tls | list | `[]` |  |
 | loadtest.environment | object | `{}` | environment variables used in the load test |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -1,6 +1,6 @@
 # locust
 
-![Version: 0.9.9](https://img.shields.io/badge/Version-0.9.9-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
+![Version: 0.9.10](https://img.shields.io/badge/Version-0.9.10-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
 
 A chart for locust
 

--- a/stable/locust/templates/master-ingress.yaml
+++ b/stable/locust/templates/master-ingress.yaml
@@ -26,6 +26,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{ $ingress := .Values.ingress }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -34,5 +35,11 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8089
+          {{- range $ingress.extraPaths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 8089
+          {{- end }}
     {{- end }}
   {{- end }}

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -104,6 +104,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  extraPaths: []
+  # - /*
 
 # extraConfigMaps -- Any extra configmaps to mount for the master and worker. Can be used for extra python packages
 extraConfigMaps: {}


### PR DESCRIPTION
Hey, we are using locust helm chart with AWS ALB Ingress controller.
Unfortunately, with ALB ingress the path has to be set as `/*` in order for locust to work correctly. Without it, all static files won't load properly, since the ALB ingress will only forward traffic from `/` and everything else (like `/static/*` will result in 404s from the ALB). More about the issue [here ](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/667#issuecomment-428175980).

To combat this issue I've added the option to set `extraPaths`, so we'll be able to add `/*` as a second path besides `/`.